### PR TITLE
Support for standard OAuth2 providers

### DIFF
--- a/libs/oauth2/src/lib.rs
+++ b/libs/oauth2/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod dex_provider;
 pub mod github_provider;
 pub mod oauth_provider;
+pub mod oauth2_provider;
 use serde::{Deserialize, Serialize};
 use std::{fs, str::FromStr};
 mod errors;
@@ -43,6 +44,7 @@ pub enum Provider {
     Azure,
     Auth0,
     Dex,
+    Oauth2,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -67,6 +69,7 @@ impl FromStr for Provider {
             "azure" => Ok(Provider::Azure),
             "auth0" => Ok(Provider::Auth0),
             "custom" => Ok(Provider::Dex),
+            "oauth2" => Ok(Provider::Oauth2),
             _ => Err(()),
         }
     }
@@ -84,6 +87,7 @@ impl Into<String> for Provider {
             Provider::Azure => "Azure".to_string(),
             Provider::Auth0 => "Auth0".to_string(),
             Provider::Dex => "Dex".to_string(),
+            Provider::Oauth2 => "Oauth2".to_string(),
         }
     }
 }

--- a/libs/oauth2/src/oauth2_provider.rs
+++ b/libs/oauth2/src/oauth2_provider.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2024 Ronan LE MEILLAT for SCTG Development
+//
+// This file is part of the SCTGDesk project.
+//
+// SCTGDesk is free software: you can redistribute it and/or modify
+// it under the terms of the Affero General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// SCTGDesk is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// Affero General Public License for more details.
+//
+// You should have received a copy of the Affero General Public License
+// along with SCTGDesk. If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
+use std::{future::Future, pin::Pin};
+
+use crate::{
+    errors::Oauth2Error,
+    oauth_provider::{decode_oauth2_id_token, OAuthProvider, OAuthProviderFactory, OAuthResponse},
+    Provider, ProviderConfig, TokenResponse,
+};
+use base64::prelude::{Engine as _, BASE64_STANDARD};
+
+use url::form_urlencoded;
+
+pub struct Oauth2Provider {
+    provider_config: ProviderConfig,
+}
+
+/// Get the authorization header for the provider
+///
+/// # Arguments
+/// * `provider_config` - The provider configuration
+///
+/// # Returns
+/// The authorization header
+fn get_authorization_header(provider_config: &ProviderConfig) -> String {
+    format!(
+        "Basic {}",
+        BASE64_STANDARD.encode(format!(
+            "{}:{}",
+            provider_config.app_id, provider_config.app_secret
+        ))
+    )
+}
+
+impl OAuthProviderFactory for Oauth2Provider {
+    fn new() -> Self {
+        let provider_config = Self::get_provider_config(Provider::Oauth2);
+        Self { provider_config }
+    }
+}
+impl OAuthProvider for Oauth2Provider {
+    fn get_redirect_url(&self, callback_url: &str, state: &str) -> String {
+        let redirect_url =
+            form_urlencoded::byte_serialize(callback_url.as_bytes()).collect::<String>();
+        let scope = form_urlencoded::byte_serialize(self.provider_config.scope.as_bytes())
+            .collect::<String>();
+        let state = form_urlencoded::byte_serialize(state.as_bytes()).collect::<String>();
+
+        format!(
+            "{}?client_id={}&redirect_uri={}&response_type=code&scope={}&state={}",
+            self.provider_config.authorization_url,
+            self.provider_config.app_id,
+            redirect_url,
+            scope,
+            state
+        )
+    }
+
+    fn exchange_code(
+        &self,
+        code: &str,
+        callback_url: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<OAuthResponse, Oauth2Error>> + Send + Sync>> {
+        let code = code.to_string();
+        let callback_url = callback_url.to_string();
+        let provider_config = self.provider_config.clone();
+
+        Box::pin(async move {
+            let code = form_urlencoded::byte_serialize(code.as_bytes()).collect::<String>();
+            let authorization_header = get_authorization_header(&provider_config);
+            let response = reqwest::Client::new()
+                .post(provider_config.token_exchange_url.as_str())
+                .header("Authorization", authorization_header)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .form(&[
+                    ("grant_type", "authorization_code"),
+                    ("code", code.as_str()),
+                    ("redirect_uri", &callback_url),
+                    ("client_id", &provider_config.app_id.as_str()),
+                    ("client_secret", &provider_config.app_secret.as_str()),
+                ])
+                .send()
+                .await
+                .map_err(|_| Oauth2Error::ExchangeCodeError)?;
+
+            let response = response
+                .error_for_status()
+                .map_err(|_| Oauth2Error::ExchangeCodeError)?;
+
+            let body = response
+                .json::<TokenResponse>()
+                .await
+                .map_err(|_| Oauth2Error::ExchangeCodeError)?;
+
+            if let Some(id_token) = body.id_token {
+                let (username, email) = decode_oauth2_id_token(&id_token)?;
+                Ok(OAuthResponse {
+                    access_token: body.access_token,
+                    username,
+                    email,
+                })
+            } else {
+                Err(Oauth2Error::ExchangeCodeError)
+            }
+        })
+    }
+
+    fn get_provider_type(&self) -> crate::Provider {
+        Provider::Oauth2
+    }
+}

--- a/libs/oauth2/src/oauth_provider.rs
+++ b/libs/oauth2/src/oauth_provider.rs
@@ -78,3 +78,14 @@ pub fn decode_oauth_id_token(id_token: &str) -> Result<(String, String), Oauth2E
         serde_json::from_slice(&claims).map_err(|_| Oauth2Error::DecodeIdTokenError)?;
     Ok((claims.name, claims.email))
 }
+
+/// Decode the standard Oauth2 id token
+pub fn decode_oauth2_id_token(id_token: &str) -> Result<(String, String), Oauth2Error> {
+    let parts: Vec<&str> = id_token.split('.').collect();
+    let claims = BASE64_URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .map_err(|_| Oauth2Error::DecodeIdTokenError)?;
+    let claims: serde_json::Value =
+        serde_json::from_slice(&claims).map_err(|_| Oauth2Error::DecodeIdTokenError)?;
+    Ok((claims["name"].as_str().unwrap().to_string(), claims["email"].as_str().unwrap().to_string()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1045,6 +1045,7 @@ async fn oidc_auth(
             oauth2::Provider::Azure => todo!(),
             oauth2::Provider::Auth0 => todo!(),
             oauth2::Provider::Dex => Arc::new(oauth2::dex_provider::DexProvider::new()),
+            oauth2::Provider::Oauth2 => Arc::new(oauth2::oauth2_provider::Oauth2Provider::new()),
         }
     };
 


### PR DESCRIPTION
This pull request provide support for more OAuth2 openid providers, not just dex. Like facebook, gitlab, google etc.

The dex_provider have 2 problems for custom provider:
1. The original ```decode_oauth_id_token``` function use struct to handle decoded id_token data, which will failed if the id_token have more value. Reason: "This conversion can fail if the structure of the input does not match the structure". See [Rust doc](https://docs.rs/serde_json/latest/serde_json/fn.from_slice.html).
2. When request refresh_token, the client_secret is missing. This will cause most oauth2 provider return 401 error because client_secret is required.

Improvement:
1. Use type serde_json::Value instead of Claims struct to handle decoded id_token data.
2. Add client_secret when request refresh_token.

Tested on provider:
github.com/casdoor/casdoor
Dex may works as is.

Example oauth2.toml for casdoor
```
[[provider]]
provider = "Oauth2"
authorization_url = "https://casdoor.example.com/login/oauth/authorize"
token_exchange_url = "https://casdoor.example.com/api/login/oauth/access_token"
app_id = "c27gd83g8gdf623gf8g8f1"
app_secret = "3y74bc98937fhcg739f83f"
op_auth_string = "oidc/casdoor"
op = "casdoor"
scope = "openid email profile"
```