### PR TITLE
Fix error 500 in docker version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2014,7 +2014,7 @@ async fn software(key: &str) -> Result<Json<SoftwareResponse>, status::NotFound<
 #[get("/api/software/version/server", format = "application/json")]
 async fn software_version() -> Json<SoftwareVersionResponse> {
     log::debug!("software_version");
-    let version = env::var("MAIN_PKG_VERSION").unwrap();
+    let version = env::var("MAIN_PKG_VERSION").unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
     let response = SoftwareVersionResponse {
         server: Some(version),
         client: Some(extract_version().await.unwrap_or("0.0.0".to_string())),


### PR DESCRIPTION
I was getting error 500 logs in browser console so I decided to check it out

```
GET /api/software/version/server application/json:
   >> Matched: (software_version) GET /api/software/version/server application/json

--> src/lib.rs:2016
        software_version
   >> Handler software_version panicked.
   >> This is an application bug.
   >> A panic in Rust must be treated as an exceptional event.
   >> Panicking is not a suitable error handling mechanism.
   >> Unwinding, the result of a panic, is an expensive operation.
   >> Panics will degrade application performance.
   >> Instead of panicking, return `Option` and/or `Result`.
   >> Values of either type can be returned directly from handlers.
   >> A panic is treated as an internal server error.
   >> Outcome: Error(500 Internal Server Error)
   >> No 500 catcher registered. Using Rocket default.

--> /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rocket-0.5.0/src/server.rs:163
        sending response: Response {
    status: 500,
    version: HTTP/1.1,
    headers: {
        "content-type": "application/json",
        "server": "SCTGDeskApiServer/1.1.99-47",
        "x-frame-options": "SAMEORIGIN",
        "permissions-policy": "interest-cohort=()",
        "x-content-type-options": "nosniff",
        "access-control-allow-origin": "*",
        "access-control-allow-methods": "POST, GET, PUT, DELETE, OPTIONS",
        "access-control-allow-headers": "*",
        "access-control-allow-credentials": "true",
        "content-length": "169",
    },
    body: Body(
        Streaming,
    ),
}
```